### PR TITLE
Continuous SPI clocking

### DIFF
--- a/fw/spi.c
+++ b/fw/spi.c
@@ -174,6 +174,10 @@ int32_t spi(uint32_t device, uint32_t rwLen, uint8_t *wBuff, uint8_t *rBuff) {
 		while(!(SPIx->SR & SPI_I2S_FLAG_RXNE)){};
 			rBuff[j++] = SPIx->DR;
 
+		// This appears redundant with BSY, however the manual states:
+		// Wait until TXE=1 and then wait until BSY=0 before disabling the SPI.
+		while(!(SPIx->SR & SPI_I2S_FLAG_TXE)){};
+
 		// Wait for SPI comms to finish
 		while(SPIx->SR & SPI_I2S_FLAG_BSY){};
 


### PR DESCRIPTION
Avoid waiting for BSY to go low between SPI bytes. This caused a discontinuous SPI clock (8 cycles, then delay, then 8 cycles). The delays are fine for many devices, but not for an ADC which needs continuous clocking for 16 cycles.

Also changed the SPI peripheral enable and disable to occur at the beginning and end of a SPI transaction. This will cause a change in behavior (SPI clock will go low between calls to SPI commands). This shouldn't be an issue given that the chip-select line will also be high and will only go low AFTER the clock returns to the high state (prior to data transfer). Previously there were some glitches which probably didn't affect anything (also because CS was high).